### PR TITLE
error handling when song is not found

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,11 +91,16 @@ var lyricist = function(key){
   function _search(query, callback){
     genius.search(query, function (error, response){
       if(error){ return(callback(error)); }
-      var song = JSON.parse(response).response.hits[0].result;
-      _scrapeLyrics(song.path, function(error, lyrics){
-        song.lyrics = lyrics;
-        callback(error, song);
-      });
+      var response = JSON.parse(response).response;
+      if(response.hits.length){
+        var song = response.hits[0].result;
+         _scrapeLyrics(song.path, function(error, lyrics){
+          song.lyrics = lyrics;
+          callback(error, song);
+         });
+      } else {
+        callback(new Error('Song not found'), null);
+      }
     });
   } // End of _search()
 


### PR DESCRIPTION
Firstly, thanks for creating this library @scf4 ,

I am using this library to fetch lyrics for the currently playing Spotify track for my Spotify client app. 

Just realized if you try to fetch the lyrics to a song which does not exist on Genius, library fails:

**/Users/erselaker/spotify-cli/node_modules/lyricist/lib/index.js:95**
      **var song = JSON.parse(response).response.hits[0].result;**
**TypeError: Cannot read property 'result' of undefined**

Usage in my code:
```
			lyricist.song({search: `${trackInfo.artist} ${trackInfo.track}`}, function (err, song) {
				if(err){
					console.log(`Could not find lyrics for track: ${trackInfo.track} - ${trackInfo.artist}`);
				} else {
					console.log('${trackInfo.track} - ${trackInfo.artist} Lyrics')
					console.log(song.lyrics);
}
```

I have updated the lib code to do error handling whilst parsing lyrics, let me know if I should be using the library in other way to prevent this from happening.