### PR TITLE
Revamp artistByName() function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,13 +73,17 @@ module.exports = class Lyricist {
   }
 
   /*
-    Get artist by exact name (undocumented, likely to change)
-    Potentially unreliable, use at own risk! ⚠️
+    Get artist by exact name
   */
 
   async artistByName(name, opts) {
-    const slug = this._geniusSlug(name);
-    const id = await this._scrapeArtistPageForArtistID(slug);
+    if (!name)
+      throw new Error('No name was provided to lyricist.artistByName()');
+    let search = await this.search(name);
+    let artist = search
+      .filter(i => i.primary_artist.name === name)
+      .map(i => i.primary_artist)[0];
+    let id = artist.id;
     return this.artist(id, opts);
   }
 
@@ -127,34 +131,5 @@ module.exports = class Lyricist {
     return $('.lyrics')
       .text()
       .trim();
-  }
-
-  /* Get slug from name/title */
-
-  _geniusSlug(string) {
-    // Probably not 100% accurate yet
-    // Currently only used by undocumented artistByName function
-    const slug = string
-      .trim()
-      .replace(/\s+/g, '-')
-      .replace("'", '')
-      .replace('&', 'and')
-      .replace(/[^a-zA-Z0-9]/g, '-')
-      .toLowerCase();
-    // Uppercase first letter
-    return slug.charAt(0).toUpperCase() + slug.slice(1);
-  }
-
-  /* Scrape artist page to retrieve artist ID */
-
-  async _scrapeArtistPageForArtistID(slug) {
-    const url = `https://genius.com/artists/${slug}`;
-    const html = await fetch(url).then(res => res.text());
-    const $ = cheerio.load(html);
-    const id = $('meta[name="newrelic-resource-path"]')
-      .attr('content')
-      .split('/')
-      .pop();
-    return id;
   }
 };

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -49,27 +49,6 @@ describe('Lyricist', () => {
     });
   });
 
-  describe('_geniusSlug', () => {
-    test('converts a name/title to the slug used by genius.com', async () => {
-      const namesAndExpectedSlugs = {
-        'Kanye West': 'Kanye-west',
-        'A$AP Rocky': 'A-ap-rocky',
-        'Alt J': 'Alt-j',
-      };
-      const names = Object.keys(namesAndExpectedSlugs);
-      const expectedSlugs = names.map(name => namesAndExpectedSlugs[name]);
-      const slugs = names.map(lyricist._geniusSlug);
-      expect(slugs).toEqual(expectedSlugs);
-    });
-  });
-
-  describe('_scrapeArtistPageForArtistID', () => {
-    test('scrape an artist page and return their genius ID', async () => {
-      const result = await lyricist._scrapeArtistPageForArtistID('Son-lux');
-      expect(result).toEqual('94423');
-    });
-  });
-
   describe('song()', () => {
     test('throw an error if no ID is given', async done => {
       try {


### PR DESCRIPTION
## Changes
- Revamp artistByName() function, get rid of _geniusSlug() and _scrapeArtistPageForArtistID() functions (commit b6ee281)
- Get rid of tests for _geniusSlug() and _scrapeArtistPageForArtistID() functions (commit 39e5883)

## Description
I re-wrote the `artistByName()` function to make use of the `search()` method. It searches the name provided on the API, filters results to only contain songs that have the exact same artist as provided, gets the ID of the artist and then uses the `artist()` method to return the whole artist object.
I think this will be more reliable than generating slugs and scraping the artist's page; this whole method is done within the API itself using scopes provided by the official API.
Also, I removed tests for the slug and scrape methods as they aren't necessary after making this change.