### PR TITLE
Fix with Genius UI update

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -133,8 +133,12 @@ module.exports = class Lyricist {
         const between = text.substr(0, end).trim();
         const [, jstring] = between.match(/JSON\.parse\('(.+)'\);$/);
         const parsed = JSON.parse(JSON.parse('"' + jstring.replace(/\\'/g, "'") + '"'));
-        lyrics = parsed.songPage.lyricsData.body.children[0].children
-           .map(child => typeof child === "string" ? child : "\n").join("");
+        const child_map = child => {
+          if(typeof child === "string") return child;
+          if(child.tag === "br") return "\n";
+          return (child.children || []).map(child_map).join("");
+        };
+        lyrics = parsed.songPage.lyricsData.body.children[0].children.map(child_map).join("");
         return true;
       }
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -119,14 +119,26 @@ module.exports = class Lyricist {
   }
 
   /* Scrape song lyrics */
-
+  
   async _scrapeLyrics(url) {
     const response = await fetch(url);
     const text = await response.text();
     const $ = cheerio.load(text);
-    return $('.lyrics')
-      .text()
-      .trim();
+    const script_elements = $("script");
+    let lyrics = "could not find lyrics";
+    script_elements.toArray().some(itm => {
+      const text = $(itm).text().trim();
+      if(text.startsWith("window.__PRELOADED_STATE__")) {
+        const end = text.indexOf("window.__APP_CONFIG__");
+        const between = text.substr(0, end).trim();
+        const [, jstring] = between.match(/JSON\.parse\('(.+)'\);$/);
+        const parsed = JSON.parse(JSON.parse('"' + jstring.replace(/\\'/g, "'") + '"'));
+        lyrics = parsed.songPage.lyricsData.body.children[0].children
+           .map(child => typeof child === "string" ? child : "\n").join("");
+        return true;
+      }
+    });
+    return lyrics;
   }
 
   /* Get slug from name/title */


### PR DESCRIPTION
The lyrics are now shown in two places in the html, once in the thing with the class `.lyrics` and once for react preloading or something in a script tag. I would have used the one in the `.lyrics` div but cheerio doesn't seem to have anything similar to html `.innerText` that gets the text content including  `<br />` tags as newlines. There might be an easier way to do this than what I've done.